### PR TITLE
Fix modin pytests

### DIFF
--- a/Embedded/DBEngine.cpp
+++ b/Embedded/DBEngine.cpp
@@ -497,7 +497,7 @@ class DBEngineImpl : public DBEngine {
   Catalog_Namespace::UserMetadata user_;
   bool is_temp_db_;
   std::string udf_filename_;
-std::shared_ptr<CursorImpl> cursor_;
+  std::shared_ptr<CursorImpl> cursor_;
 
   std::vector<std::string> system_folders_ = {
     "mapd_catalogs", 

--- a/Embedded/DBEngine.h
+++ b/Embedded/DBEngine.h
@@ -42,8 +42,8 @@ class DBEngine {
   virtual ~DBEngine() {}
   void reset();
   void executeDDL(const std::string& query);
-  std::unique_ptr<Cursor> executeDML(const std::string& query);
-  std::unique_ptr<Cursor> executeRA(const std::string& query);
+  std::shared_ptr<Cursor> executeDML(const std::string& query);
+  std::shared_ptr<Cursor> executeRA(const std::string& query);
   void createArrowTable(const std::string&, std::shared_ptr<arrow::Table>& table);
   static DBEngine* create(const std::string& path = "", int port = DEFAULT_CALCITE_PORT);
   static DBEngine* create(const std::map<std::string, std::string>& parameters);

--- a/Embedded/Python/DBEngine.pxd
+++ b/Embedded/Python/DBEngine.pxd
@@ -85,8 +85,8 @@ cdef extern from "DBEngine.h" namespace 'EmbeddedDatabase':
 
     cdef cppclass DBEngine:
         void executeDDL(string)
-        unique_ptr[Cursor] executeDML(string)
-        unique_ptr[Cursor] executeRA(string)
+        shared_ptr[Cursor] executeDML(string)
+        shared_ptr[Cursor] executeRA(string)
         vector[string] getTables()
         vector[ColumnDetails] getTableDetails(string)
         void createArrowTable(string, shared_ptr[CTable]&)

--- a/Embedded/Python/dbe.pyx
+++ b/Embedded/Python/dbe.pyx
@@ -106,7 +106,7 @@ cdef class PyRow:
 
 
 cdef class PyCursor:
-    cdef unique_ptr[_Cursor] c_cursor  #Hold a C++ instance which we're wrapping
+    cdef shared_ptr[_Cursor] c_cursor  #Hold a C++ instance which we're wrapping
     cdef shared_ptr[CRecordBatch] c_batch
 
     def colCount(self):


### PR DESCRIPTION
In order to fix modin pytests:
 unic_ptr was replaced by shared_ptr and origin recordset stored on C++ side.