### PR TITLE
Singeltone interface to DBEngine

### DIFF
--- a/Embedded/DBEngine.cpp
+++ b/Embedded/DBEngine.cpp
@@ -108,7 +108,7 @@ public:
         [&] {
             engine_.reset(new DBEngineImpl(base_path, port, udf_filename));
     });
-    return !!engine_;
+    return engine_! = nullptr;
   }
 
   ~DBEngineImpl() { reset_query_runner(); }
@@ -538,6 +538,7 @@ bool DBEngine::init(const std::map<std::string, std::string>& parameters) {
       } else {
         std::cerr << "WARNING: ignoring unknown DBEngine parameter '" << key << "'"
                   << std::endl;
+        return false;
       }
     }
     return DBEngineImpl::init(path, port, udf_filename);

--- a/Embedded/DBEngine.cpp
+++ b/Embedded/DBEngine.cpp
@@ -555,11 +555,6 @@ inline const DBEngineImpl* getImpl(const DBEngine* ptr) {
 
 /** DBEngine external methods */
 
-void DBEngine::reset() {
-  DBEngineImpl* engine = getImpl(this);
-  engine->reset();
-}
-
 void DBEngine::executeDDL(const std::string& query) {
   DBEngineImpl* engine = getImpl(this);
   engine->executeDDL(query);

--- a/Embedded/DBEngine.h
+++ b/Embedded/DBEngine.h
@@ -47,9 +47,9 @@ class DBEngine {
   void importArrowTable(const std::string& name,
                         std::shared_ptr<arrow::Table>& table,
                         uint64_t fragment_size = 0);
-  static DBEngine* init(const std::string& path = "", int port = DEFAULT_CALCITE_PORT);
-  static DBEngine* init(const std::map<std::string, std::string>& parameters);
-  static DBEngine* get();
+  static bool init(const std::string& path = "", int port = DEFAULT_CALCITE_PORT);
+  static bool init(const std::map<std::string, std::string>& parameters);
+  static std::shared_ptr<DBEngine> get();
   std::vector<std::string> getTables();
   std::vector<ColumnDetails> getTableDetails(const std::string& table_name);
   void createUser(const std::string& user_name, const std::string& password);

--- a/Embedded/DBEngine.h
+++ b/Embedded/DBEngine.h
@@ -48,8 +48,9 @@ class DBEngine {
   void importArrowTable(const std::string& name,
                         std::shared_ptr<arrow::Table>& table,
                         uint64_t fragment_size = 0);
-  static DBEngine* create(const std::string& path = "", int port = DEFAULT_CALCITE_PORT);
-  static DBEngine* create(const std::map<std::string, std::string>& parameters);
+  static DBEngine* init(const std::string& path = "", int port = DEFAULT_CALCITE_PORT);
+  static DBEngine* init(const std::map<std::string, std::string>& parameters);
+  static DBEngine* get();
   std::vector<std::string> getTables();
   std::vector<ColumnDetails> getTableDetails(const std::string& table_name);
   void createUser(const std::string& user_name, const std::string& password);

--- a/Embedded/DBEngine.h
+++ b/Embedded/DBEngine.h
@@ -41,7 +41,6 @@ class Cursor {
 class DBEngine {
  public:
   virtual ~DBEngine() {}
-  void reset();
   void executeDDL(const std::string& query);
   std::unique_ptr<Cursor> executeDML(const std::string& query);
   std::unique_ptr<Cursor> executeRA(const std::string& query);

--- a/Embedded/EmbeddedDbFSITest.cpp
+++ b/Embedded/EmbeddedDbFSITest.cpp
@@ -69,7 +69,7 @@ int main(int argc, char* argv[]) {
     std::map<std::string, std::string> parameters = {
       {"path", base_path},
       {"port", std::to_string(calcite_port)}};
-    DBEngine* dbe = DBEngine::create(parameters);
+    DBEngine* dbe = DBEngine::init(parameters);
     if (dbe) {
       dbe->executeDDL(R"(
 CREATE TEMPORARY TABLE test (

--- a/Embedded/EmbeddedDbFSITest.cpp
+++ b/Embedded/EmbeddedDbFSITest.cpp
@@ -69,8 +69,8 @@ int main(int argc, char* argv[]) {
     std::map<std::string, std::string> parameters = {
       {"path", base_path},
       {"port", std::to_string(calcite_port)}};
-    DBEngine* dbe = DBEngine::init(parameters);
-    if (dbe) {
+    if (DBEngine::init(parameters)) {
+      auto dbe = DBEngine::get();
       dbe->executeDDL(R"(
 CREATE TEMPORARY TABLE test (
 trip_id BIGINT,
@@ -136,7 +136,6 @@ dropoff_puma BIGINT) WITH (storage_type='CSV:/localdisk1/amalakho/omniscidb/Test
         std::cerr << "Cursor is NULL" << std::endl;
       }
     }
-    delete dbe;
   } catch (std::exception& e) {
     std::cerr << "Exception: " << e.what() << "\n";
   }

--- a/Embedded/EmbeddedDbTest.cpp
+++ b/Embedded/EmbeddedDbTest.cpp
@@ -69,7 +69,7 @@ int main(int argc, char* argv[]) {
     std::map<std::string, std::string> parameters = {
       {"path", base_path},
       {"port", std::to_string(calcite_port)}};
-    auto dbe = DBEngine::create(parameters);
+    auto dbe = DBEngine::init(parameters);
 
     if (dbe) {
       auto memory_pool = arrow::default_memory_pool();

--- a/Embedded/EmbeddedDbTest.cpp
+++ b/Embedded/EmbeddedDbTest.cpp
@@ -69,9 +69,8 @@ int main(int argc, char* argv[]) {
     std::map<std::string, std::string> parameters = {
       {"path", base_path},
       {"port", std::to_string(calcite_port)}};
-    auto dbe = DBEngine::init(parameters);
-
-    if (dbe) {
+    if (DBEngine::init(parameters)) {
+      auto dbe = DBEngine::get();
       auto memory_pool = arrow::default_memory_pool();
       auto arrow_parse_options = arrow::csv::ParseOptions::Defaults();
       auto arrow_read_options = arrow::csv::ReadOptions::Defaults();

--- a/Embedded/Python/DBEngine.pxd
+++ b/Embedded/Python/DBEngine.pxd
@@ -96,9 +96,10 @@ cdef extern from "DBEngine.h" namespace 'EmbeddedDatabase':
         void dropDatabase(string db_name)
         bool setDatabase(string db_name)
         bool login(string db_name, string user_name, string password)
-        void reset()
         @staticmethod
-        DBEngine* create(map[string, string])
+        DBEngine* init(map[string, string])
+        @staticmethod
+        DBEngine* get()
 
 cdef extern from "DBETypes.h" namespace 'EmbeddedDatabase::ColumnType':
     cdef ColumnType SMALLINT

--- a/Embedded/Python/DBEngine.pxd
+++ b/Embedded/Python/DBEngine.pxd
@@ -84,22 +84,22 @@ cdef extern from "DBEngine.h" namespace 'EmbeddedDatabase':
         shared_ptr[CRecordBatch] getArrowRecordBatch() nogil except +
 
     cdef cppclass DBEngine:
-        void executeDDL(string)
+        void executeDDL(string) except +
         unique_ptr[Cursor] executeDML(string)
         unique_ptr[Cursor] executeRA(string)
-        vector[string] getTables()
-        vector[ColumnDetails] getTableDetails(string)
-        void importArrowTable(string, shared_ptr[CTable]&, uint64_t)
-        void createUser(string user_name, string password)
-        void dropUser(string user_name)
-        void createDatabase(string db_name)
-        void dropDatabase(string db_name)
-        bool setDatabase(string db_name)
-        bool login(string db_name, string user_name, string password)
+        vector[string] getTables() except +
+        vector[ColumnDetails] getTableDetails(string) except +
+        void importArrowTable(string, shared_ptr[CTable]&, uint64_t) except +
+        void createUser(string user_name, string password) except +
+        void dropUser(string user_name) except +
+        void createDatabase(string db_name) except +
+        void dropDatabase(string db_name) except +
+        bool setDatabase(string db_name) except +
+        bool login(string db_name, string user_name, string password) except +
         @staticmethod
-        DBEngine* init(map[string, string])
+        bool init(map[string, string]) except +
         @staticmethod
-        DBEngine* get()
+        shared_ptr[DBEngine] get() except +
 
 cdef extern from "DBETypes.h" namespace 'EmbeddedDatabase::ColumnType':
     cdef ColumnType SMALLINT

--- a/QueryRunner/QueryRunner.h
+++ b/QueryRunner/QueryRunner.h
@@ -31,6 +31,8 @@
 #include "QueryEngine/OverlapsJoinHashTable.h"
 #include "ThriftHandler/QueryState.h"
 
+#define CALCITEPORT 3279
+
 namespace Catalog_Namespace {
 class Catalog;
 struct UserMetadata;
@@ -94,6 +96,11 @@ class QueryRunner {
                            const int reserved_gpu_mem = 256 << 20,
                            const bool create_user = false,
                            const bool create_db = false);
+
+  static QueryRunner* init(const char* db_path,
+                           bool is_new_catalog,
+                           int calcite_port = CALCITEPORT,
+                           const std::string& udf_filename = "");
 
   static QueryRunner* init(std::unique_ptr<Catalog_Namespace::SessionInfo>& session) {
     qr_instance_.reset(new QueryRunner(std::move(session)));
@@ -177,7 +184,10 @@ class QueryRunner {
               const size_t max_gpu_mem,
               const int reserved_gpu_mem,
               const bool create_user,
-              const bool create_db);
+              const bool create_db,
+              ExecutorDeviceType device_type = ExecutorDeviceType::GPU,
+              bool is_new_catalog = false,
+              int calcite_port = CALCITEPORT);
 
   static std::unique_ptr<QueryRunner> qr_instance_;
 

--- a/Tests/EmbeddedDatabaseTest.cpp
+++ b/Tests/EmbeddedDatabaseTest.cpp
@@ -25,8 +25,6 @@
 using namespace std;
 using namespace EmbeddedDatabase;
 
-DBEngine* engine = nullptr;
-
 class DBEngineSQLTest : public ::testing::Test {
 protected:
   DBEngineSQLTest() {}
@@ -42,29 +40,29 @@ protected:
   }
 
   int select_int(const string& query_str) {
-    auto cursor = ::engine->executeDML(query_str);
+    auto cursor = DBEngine::get()->executeDML(query_str);
     auto row = cursor->getNextRow();
     return row.getInt(0);
   }
 
   float select_float(const string& query_str) {
-    auto cursor = ::engine->executeDML(query_str);
+    auto cursor = DBEngine::get()->executeDML(query_str);
     auto row = cursor->getNextRow();
     return row.getFloat(0);
   }
 
   double select_double(const string& query_str) {
-    auto cursor = ::engine->executeDML(query_str);
+    auto cursor = DBEngine::get()->executeDML(query_str);
     auto row = cursor->getNextRow();
     return row.getDouble(0);
   }
 
   void run_ddl(const string& query_str) {
-    ::engine->executeDDL(query_str);
+    DBEngine::get()->executeDDL(query_str);
   }
 
   std::shared_ptr<arrow::RecordBatch> run_dml(const string& query_str) {
-    auto cursor = ::engine->executeDML(query_str);
+    auto cursor = DBEngine::get()->executeDML(query_str);
     return cursor ? cursor->getArrowRecordBatch(): nullptr;
   }
 };
@@ -259,7 +257,10 @@ int main(int argc, char** argv) {
   std::map<std::string, std::string> parameters = {
     {"path", std::string(BASE_PATH)}};
 
-  engine = DBEngine::init(parameters);
+  if (!DBEngine::init(parameters)) {
+    std::cout << "DBEngine initialization failed" << std::endl;
+    return 0;
+  }
 
   int err{0};
 
@@ -268,6 +269,5 @@ int main(int argc, char** argv) {
   } catch (const std::exception& e) {
     LOG(ERROR) << e.what();
   }
-  delete engine;
   return err;
 }

--- a/Tests/EmbeddedDatabaseTest.cpp
+++ b/Tests/EmbeddedDatabaseTest.cpp
@@ -259,7 +259,7 @@ int main(int argc, char** argv) {
   std::map<std::string, std::string> parameters = {
     {"path", std::string(BASE_PATH)}};
 
-  engine = DBEngine::create(parameters);
+  engine = DBEngine::init(parameters);
 
   int err{0};
 

--- a/Tests/EmbeddedDatabaseTest.cpp
+++ b/Tests/EmbeddedDatabaseTest.cpp
@@ -268,7 +268,6 @@ int main(int argc, char** argv) {
   } catch (const std::exception& e) {
     LOG(ERROR) << e.what();
   }
-  engine->reset();
-  //delete engine;
+  delete engine;
   return err;
 }


### PR DESCRIPTION
1. Singeltone interface added to DBEngine via unique_ptr.
2. Python dbe interface updated to use DBEngine singelton.
3. QueryRunner updated with new init method which allows you to set the calcite port, create new system catalog. 