### PR TITLE
Calcite needs sqlite jdbc so put it back

### DIFF
--- a/java/calcite/pom.xml
+++ b/java/calcite/pom.xml
@@ -66,11 +66,11 @@
         </exclusion>-->
       </exclusions>
     </dependency>
-<!--    <dependency>
+    <dependency>
       <groupId>org.xerial</groupId>
       <artifactId>sqlite-jdbc</artifactId>
       <version>3.30.1</version>
-    </dependency> -->
+    </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>

--- a/java/utility/pom.xml
+++ b/java/utility/pom.xml
@@ -73,11 +73,11 @@
       <artifactId>commons-math3</artifactId>
       <version>3.5</version>
     </dependency>
-<!--    <dependency>
+    <dependency>
       <groupId>org.xerial</groupId>
       <artifactId>sqlite-jdbc</artifactId>
       <version>3.30.1</version>
-    </dependency> -->
+    </dependency>
     <dependency>
       <groupId>com.unboundid</groupId>
       <artifactId>unboundid-ldapsdk</artifactId>


### PR DESCRIPTION
Unfortunately we can't get rid of sqlite jdbc even temporarily since we need Calcite and it requires jdbc hence return it back