### PR TITLE
Integrate DBE Python tests into OmnisciDB unit testing

### DIFF
--- a/Embedded/CMakeLists.txt
+++ b/Embedded/CMakeLists.txt
@@ -29,6 +29,11 @@ if(PYTHON_EXECUTABLE)
         COMMAND cd ${CMAKE_CURRENT_BINARY_DIR} && ${PYTHON_EXECUTABLE} ${SETUP_PY} build_ext -g -f -I ${CMAKE_CURRENT_SOURCE_DIR}
         DEPENDS DBEngine ${pydeps}
     )
+    add_custom_target(dbe4py-test
+        COMMAND cd ${CMAKE_CURRENT_BINARY_DIR} && ${PYTHON_EXECUTABLE} ${SETUP_PY} build_ext -g -f -I ${CMAKE_CURRENT_SOURCE_DIR}
+        COMMAND ${PYTHON_EXECUTABLE} -m pytest -v ${CMAKE_CURRENT_SOURCE_DIR}/test/test_exceptions.py
+        DEPENDS DBEngine ${pydeps} mapd_java_components
+    )
     add_custom_target(dbe4py-install
         COMMAND cd ${CMAKE_CURRENT_BINARY_DIR} && ${PYTHON_EXECUTABLE} ${SETUP_PY} build_ext -g -f -I ${CMAKE_CURRENT_SOURCE_DIR} install
         DEPENDS DBEngine ${pydeps}

--- a/Embedded/CMakeLists.txt
+++ b/Embedded/CMakeLists.txt
@@ -27,12 +27,11 @@ if(PYTHON_EXECUTABLE)
 
     add_custom_target(dbe4py
         COMMAND cd ${CMAKE_CURRENT_BINARY_DIR} && ${PYTHON_EXECUTABLE} ${SETUP_PY} build_ext -g -f -I ${CMAKE_CURRENT_SOURCE_DIR}
-        DEPENDS DBEngine ${pydeps}
+        DEPENDS DBEngine ${pydeps} mapd_java_components
     )
     add_custom_target(dbe4py-test
-        COMMAND cd ${CMAKE_CURRENT_BINARY_DIR} && ${PYTHON_EXECUTABLE} ${SETUP_PY} build_ext -g -f -I ${CMAKE_CURRENT_SOURCE_DIR}
         COMMAND ${PYTHON_EXECUTABLE} -m pytest -v ${CMAKE_CURRENT_SOURCE_DIR}/test/test_exceptions.py
-        DEPENDS DBEngine ${pydeps} mapd_java_components
+        DEPENDS dbe4py
     )
     add_custom_target(dbe4py-install
         COMMAND cd ${CMAKE_CURRENT_BINARY_DIR} && ${PYTHON_EXECUTABLE} ${SETUP_PY} build_ext -g -f -I ${CMAKE_CURRENT_SOURCE_DIR} install

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -320,6 +320,9 @@ add_custom_target(all_tests
                 ${CMAKE_CTEST_COMMAND} --verbose
     DEPENDS ${TEST_PROGRAMS} ProfileTest UtilTest RunQueryLoop StringDictionaryTest StringTransformTest StoragePerfTest
     USES_TERMINAL)
+if(ENABLE_DBE)
+  add_dependencies(all_tests dbe4py-test)
+endif()
 
 add_custom_target(storage_perf_tests
     COMMAND mkdir -p ${TEST_BASE_PATH}
@@ -332,3 +335,17 @@ add_custom_target(topk_tests
     COMMAND initdb -f ${TEST_BASE_PATH}
     COMMAND ${CMAKE_CTEST_COMMAND} --verbose --tests-regex "\"(TopKTest)\""
     DEPENDS TopKTest)
+
+if(ENABLE_DBE)
+  set(DBE_TEST_PROGRAMS EmbeddedDatabaseTest)
+  set_tests_properties(${DBE_TEST_PROGRAMS} PROPERTIES LABELS "embedded")
+  add_custom_target(dbe_tests
+    COMMAND mkdir -p ${TEST_BASE_PATH}
+    COMMAND env AWS_REGION=${AWS_REGION}
+                AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
+                AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+                ${CMAKE_CTEST_COMMAND} --verbose --label-regex embedded
+    DEPENDS DBEngine ${DBE_TEST_PROGRAMS}
+    USES_TERMINAL)
+  add_dependencies(dbe_tests dbe4py-test)
+endif()

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -320,9 +320,6 @@ add_custom_target(all_tests
                 ${CMAKE_CTEST_COMMAND} --verbose
     DEPENDS ${TEST_PROGRAMS} ProfileTest UtilTest RunQueryLoop StringDictionaryTest StringTransformTest StoragePerfTest
     USES_TERMINAL)
-if(ENABLE_DBE)
-  add_dependencies(all_tests dbe4py-test)
-endif()
 
 add_custom_target(storage_perf_tests
     COMMAND mkdir -p ${TEST_BASE_PATH}
@@ -339,7 +336,7 @@ add_custom_target(topk_tests
 if(ENABLE_DBE)
   set(DBE_TEST_PROGRAMS EmbeddedDatabaseTest)
   set_tests_properties(${DBE_TEST_PROGRAMS} PROPERTIES LABELS "embedded")
-  add_custom_target(dbe_tests
+  add_custom_target(dbe_all_tests
     COMMAND mkdir -p ${TEST_BASE_PATH}
     COMMAND env AWS_REGION=${AWS_REGION}
                 AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
@@ -347,5 +344,6 @@ if(ENABLE_DBE)
                 ${CMAKE_CTEST_COMMAND} --verbose --label-regex embedded
     DEPENDS DBEngine ${DBE_TEST_PROGRAMS}
     USES_TERMINAL)
-  add_dependencies(dbe_tests dbe4py-test)
+  add_dependencies(dbe_all_tests dbe4py-test)
+  add_dependencies(all_tests dbe4py-test)
 endif()

--- a/ThriftHandler/CMakeLists.txt
+++ b/ThriftHandler/CMakeLists.txt
@@ -14,6 +14,7 @@ else()
 endif()
 
 add_library(QueryState QueryState.cpp)
+add_dependencies(QueryState thrift_gen)
 
 add_library(token_completion_hints TokenCompletionHints.cpp)
 target_link_libraries(token_completion_hints mapd_thrift)


### PR DESCRIPTION
1. New cmake target added: dbe_tests. It builds just DBE libraries (libDBEngine.so, dbe.so) and run C++ and Python tests for DBE only. It also generates calcite jar.

2. DBE tests (C++ and Python) added to all_tests target.

3.  thrift_gen dependency added to QueryState library because it requires the gen-cpp files.