### PR TITLE
Map Omnisci exceptions to Python exceptions in DBE

### DIFF
--- a/Embedded/DBEngine.cpp
+++ b/Embedded/DBEngine.cpp
@@ -181,6 +181,7 @@ class DBEngineImpl : public DBEngine {
                                        is_new_db);
     } catch (const std::exception& e) {
       LOG(FATAL) << "Failed to initialize database handler: " << e.what();
+      throw;
     }
     db_handler_->connect(
         session_id_, OMNISCI_ROOT_USER, OMNISCI_ROOT_PASSWD_DEFAULT, OMNISCI_DEFAULT_DB);
@@ -210,6 +211,10 @@ class DBEngineImpl : public DBEngine {
       col_names.push_back(target.get_resname());
     }
     return std::make_shared<CursorImpl>(result.getRows(), col_names);
+  }
+
+  void executeDDL(const std::string& query) {
+    auto res = sql_execute_dbe(session_id_, query, false, -1, -1);
   }
 
   void importArrowTable(const std::string& name,
@@ -418,6 +423,7 @@ class DBEngineImpl : public DBEngine {
     }
     return root_dir;
   }
+
  private:
   std::string base_path_;
   std::string session_id_;
@@ -474,7 +480,7 @@ void DBEngine::importArrowTable(const std::string& name,
                                 std::shared_ptr<arrow::Table>& table,
                                 uint64_t fragment_size) {
   DBEngineImpl* engine = getImpl(this);
-  return engine->importArrowTable(name, table, fragment_size);
+  engine->importArrowTable(name, table, fragment_size);
 }
 
 std::vector<std::string> DBEngine::getTables() {

--- a/scripts/mapd-deps-conda-dev-env.yml
+++ b/scripts/mapd-deps-conda-dev-env.yml
@@ -15,8 +15,8 @@ channels:
   - conda-forge
 
 dependencies:
-  - gxx_linux-64   8.*
-  - gcc_linux-64   8.*
+  - gxx_linux-64   9.*
+  - gcc_linux-64   9.*
   - ccache
   - libgdal    >=2.3
   - sysroot_linux-64 >=2.14


### PR DESCRIPTION
Map Omnisci exceptions to Python exceptions in DBE #2861

I decided to not process all the list of the omnisci exceptions in the DBE  and use only the basic ones. The reason is that the list of exceptions is large and requires linking many files, since they are not included in one header. But they are inherited from the base std::exception, which allows us to get the error string on the Python side.
Below is a list of omnisci exceptions:

TException
TTransportException
InvalidParseRequest
CudaErrorException
OutOfMemory
TooBigForSlab
ForeignStorageException
FailedToCreateSlab                                                                                                                                                                                                                                 
PostEvictionRefreshException(e);
GeoTypesError
InsufficientBufferSizeException
GeoImportException
ArrowImporterException
QueryExecutionError
QueryMustRunOnCpu
WatchdogException
QueryMustRunOnCpu
ColumnarConversionNotSupported
TooManyLiterals
ReductionRanOutOfSlots
OverflowOrUnderflow
CompilationRetryNewScanLimit
NativeExecutionError
ExtensionFunctionBindingError
FailedToCreateBitmap
ParseIRError
CardinalityEstimationRequired
CompilationRetryNoLazyFetch
SpeculativeTopNFailed
StreamingTopNNotSupportedInRenderQuery
QueryNotSupported
RowSortException
SpeculativeTopNFailed
CompilationRetryNoCompaction
StreamingTopNOOM
OutOfHostMemory
OutOfRenderMemory
SringConstInResultSet
TableMustBeReplicated
HashJoinFail
TooManyHashEntries
FailedToJoinOnVirtualColumn
FailedToFetchColumn
OverlapsHashTableTooBig
NeedsOneToManyHash