### PR TITLE
Map Omnisci exceptions to Python exceptions in DBE

### DIFF
--- a/Embedded/DBEngine.cpp
+++ b/Embedded/DBEngine.cpp
@@ -28,12 +28,6 @@
 #include "ThriftHandler/CommandLineOptions.h"
 #include "ThriftHandler/DBHandler.h"
 
-#include "gen-cpp/OmniSci.h"
-#include "QueryEngine/ErrorHandling.h"
-#include "QueryEngine/Execute.h"
-#include "Shared/checked_alloc.h"
-
-
 extern bool g_enable_union;
 extern bool g_serialize_temp_tables;
 
@@ -152,48 +146,44 @@ class DBEngineImpl : public DBEngine {
     prog_config_opts.system_parameters.omnisci_server_port = -1;
     prog_config_opts.system_parameters.calcite_keepalive = true;
     try {
-      try {
-        db_handler_ =
-            mapd::make_shared<DBHandler>(prog_config_opts.db_leaves,
-                                         prog_config_opts.string_leaves,
-                                         prog_config_opts.base_path,
-                                         prog_config_opts.allow_multifrag,
-                                         prog_config_opts.jit_debug,
-                                         prog_config_opts.intel_jit_profile,
-                                         prog_config_opts.read_only,
-                                         prog_config_opts.allow_loop_joins,
-                                         prog_config_opts.enable_rendering,
-                                         prog_config_opts.renderer_use_vulkan_driver,
-                                         prog_config_opts.enable_auto_clear_render_mem,
-                                         prog_config_opts.render_oom_retry_threshold,
-                                         prog_config_opts.render_mem_bytes,
-                                         prog_config_opts.max_concurrent_render_sessions,
-                                         prog_config_opts.reserved_gpu_mem,
-                                         prog_config_opts.render_compositor_use_last_gpu,
-                                         prog_config_opts.num_reader_threads,
-                                         prog_config_opts.authMetadata,
-                                         prog_config_opts.system_parameters,
-                                         prog_config_opts.enable_legacy_syntax,
-                                         prog_config_opts.idle_session_duration,
-                                         prog_config_opts.max_session_duration,
-                                         prog_config_opts.enable_runtime_udf,
-                                         prog_config_opts.udf_file_name,
-                                         prog_config_opts.udf_compiler_path,
-                                         prog_config_opts.udf_compiler_options,
+      db_handler_ =
+        mapd::make_shared<DBHandler>(prog_config_opts.db_leaves,
+                                     prog_config_opts.string_leaves,
+                                     prog_config_opts.base_path,
+                                     prog_config_opts.allow_multifrag,
+                                     prog_config_opts.jit_debug,
+                                     prog_config_opts.intel_jit_profile,
+                                     prog_config_opts.read_only,
+                                     prog_config_opts.allow_loop_joins,
+                                     prog_config_opts.enable_rendering,
+                                     prog_config_opts.renderer_use_vulkan_driver,
+                                     prog_config_opts.enable_auto_clear_render_mem,
+                                     prog_config_opts.render_oom_retry_threshold,
+                                     prog_config_opts.render_mem_bytes,
+                                     prog_config_opts.max_concurrent_render_sessions,
+                                     prog_config_opts.reserved_gpu_mem,
+                                     prog_config_opts.render_compositor_use_last_gpu,
+                                     prog_config_opts.num_reader_threads,
+                                     prog_config_opts.authMetadata,
+                                     prog_config_opts.system_parameters,
+                                     prog_config_opts.enable_legacy_syntax,
+                                     prog_config_opts.idle_session_duration,
+                                     prog_config_opts.max_session_duration,
+                                     prog_config_opts.enable_runtime_udf,
+                                     prog_config_opts.udf_file_name,
+                                     prog_config_opts.udf_compiler_path,
+                                     prog_config_opts.udf_compiler_options,
 #ifdef ENABLE_GEOS
-                                         prog_config_opts.libgeos_so_filename,
+                                     prog_config_opts.libgeos_so_filename,
 #endif
-                                         prog_config_opts.disk_cache_config,
-                                         is_new_db);
-      } catch (const std::exception& e) {
-        LOG(FATAL) << "Failed to initialize database handler: " << e.what();
-        throw;
-      }
-      db_handler_->connect(
-          session_id_, OMNISCI_ROOT_USER, OMNISCI_ROOT_PASSWD_DEFAULT, OMNISCI_DEFAULT_DB);
-    } catch (const apache::thrift::TException& ex) {
-      throw std::runtime_error(ex.what());
+                                     prog_config_opts.disk_cache_config,
+                                     is_new_db);
+    } catch (const std::exception& e) {
+      LOG(FATAL) << "Failed to initialize database handler: " << e.what();
+      throw;
     }
+    db_handler_->connect(
+        session_id_, OMNISCI_ROOT_USER, OMNISCI_ROOT_PASSWD_DEFAULT, OMNISCI_DEFAULT_DB);
     base_path_ = base_path;
     initialized = true;
     return true;
@@ -204,26 +194,22 @@ class DBEngineImpl : public DBEngine {
                                               const bool column_format,
                                               const int32_t first_n,
                                               const int32_t at_most_n) {
-    try {
-      ExecutionResult result{std::make_shared<ResultSet>(std::vector<TargetInfo>{},
-                                                         ExecutorDeviceType::CPU,
-                                                         QueryMemoryDescriptor(),
-                                                         nullptr,
-                                                         nullptr,
-                                                         0,
-                                                         0),
-                             {}};
-      db_handler_->sql_execute(
-          result, session_id, query_str, column_format, first_n, at_most_n);
-      auto& targets = result.getTargetsMeta();
-      std::vector<std::string> col_names;
-      for (const auto target : targets) {
-        col_names.push_back(target.get_resname());
-      }
-      return std::make_shared<CursorImpl>(result.getRows(), col_names);
-    } catch (const apache::thrift::TException& ex) {
-      throw std::runtime_error(ex.what());
+    ExecutionResult result{std::make_shared<ResultSet>(std::vector<TargetInfo>{},
+                                                       ExecutorDeviceType::CPU,
+                                                       QueryMemoryDescriptor(),
+                                                       nullptr,
+                                                       nullptr,
+                                                       0,
+                                                       0),
+                           {}};
+    db_handler_->sql_execute(
+        result, session_id, query_str, column_format, first_n, at_most_n);
+    auto& targets = result.getTargetsMeta();
+    std::vector<std::string> col_names;
+    for (const auto target : targets) {
+      col_names.push_back(target.get_resname());
     }
+    return std::make_shared<CursorImpl>(result.getRows(), col_names);
   }
 
   void executeDDL(const std::string& query) {
@@ -257,9 +243,6 @@ class DBEngineImpl : public DBEngine {
       catalog->createTable(td, cols, dictionaries, false);
       Catalog_Namespace::SysCatalog::instance().createDBObject(
           session.get_currentUser(), td.tableName, TableDBObjectType, *catalog);
-    } catch (const apache::thrift::TException& ex) {
-      releaseArrowTable(name);
-      throw std::runtime_error(ex.what());
     } catch (...) {
       releaseArrowTable(name);
       throw;
@@ -277,94 +260,78 @@ class DBEngineImpl : public DBEngine {
 
   std::vector<std::string> getTables() {
     std::vector<std::string> table_names;
-    try {
-      auto& catalog = db_handler_->get_session_copy(session_id_).getCatalog();
-      const auto tables = catalog.getAllTableMetadata();
-      for (const auto td : tables) {
-        if (td->shard >= 0) {
-          // skip shards, they're not standalone tables
-          continue;
-        }
-        table_names.push_back(td->tableName);
+    auto& catalog = db_handler_->get_session_copy(session_id_).getCatalog();
+    const auto tables = catalog.getAllTableMetadata();
+    for (const auto td : tables) {
+      if (td->shard >= 0) {
+        // skip shards, they're not standalone tables
+        continue;
       }
-    } catch (const apache::thrift::TException& ex) {
-      throw std::runtime_error(ex.what());
+      table_names.push_back(td->tableName);
     }
     return table_names;
   }
 
   std::vector<ColumnDetails> getTableDetails(const std::string& table_name) {
     std::vector<ColumnDetails> result;
-    try {
-      auto& catalog = db_handler_->get_session_copy(session_id_).getCatalog();
-      auto metadata = catalog.getMetadataForTable(table_name, false);
-      if (metadata) {
-        const auto col_descriptors =
-            catalog.getAllColumnMetadataForTable(metadata->tableId, false, true, false);
-        const auto deleted_cd = catalog.getDeletedColumn(metadata);
-        for (const auto cd : col_descriptors) {
-          if (cd == deleted_cd) {
-            continue;
-          }
-          ColumnDetails col_details;
-          col_details.col_name = cd->columnName;
-          auto ct = cd->columnType;
-          SQLTypes sql_type = ct.get_type();
-          EncodingType sql_enc = ct.get_compression();
-          col_details.col_type = sqlToColumnType(sql_type);
-          col_details.encoding = sqlToColumnEncoding(sql_enc);
-          col_details.nullable = !ct.get_notnull();
-          col_details.is_array = (sql_type == kARRAY);
-          if (IS_GEO(sql_type)) {
-            col_details.precision = static_cast<int>(ct.get_subtype());
-            col_details.scale = ct.get_output_srid();
-          } else {
-            col_details.precision = ct.get_precision();
-            col_details.scale = ct.get_scale();
-          }
-          if (col_details.encoding == ColumnEncoding::DICT) {
-            // have to get the actual size of the encoding from the dictionary
-            // definition
-            const int dict_id = ct.get_comp_param();
-            auto dd = catalog.getMetadataForDict(dict_id, false);
-            if (dd) {
-              col_details.comp_param = dd->dictNBits;
-            } else {
-              throw std::runtime_error("Dictionary definition for column doesn't exist");
-            }
-          } else {
-            col_details.comp_param = ct.get_comp_param();
-            if (ct.is_date_in_days() && col_details.comp_param == 0) {
-              col_details.comp_param = 32;
-            }
-          }
-          result.push_back(col_details);
+    auto& catalog = db_handler_->get_session_copy(session_id_).getCatalog();
+    auto metadata = catalog.getMetadataForTable(table_name, false);
+    if (metadata) {
+      const auto col_descriptors =
+          catalog.getAllColumnMetadataForTable(metadata->tableId, false, true, false);
+      const auto deleted_cd = catalog.getDeletedColumn(metadata);
+      for (const auto cd : col_descriptors) {
+        if (cd == deleted_cd) {
+          continue;
         }
+        ColumnDetails col_details;
+        col_details.col_name = cd->columnName;
+        auto ct = cd->columnType;
+        SQLTypes sql_type = ct.get_type();
+        EncodingType sql_enc = ct.get_compression();
+        col_details.col_type = sqlToColumnType(sql_type);
+        col_details.encoding = sqlToColumnEncoding(sql_enc);
+        col_details.nullable = !ct.get_notnull();
+        col_details.is_array = (sql_type == kARRAY);
+        if (IS_GEO(sql_type)) {
+          col_details.precision = static_cast<int>(ct.get_subtype());
+          col_details.scale = ct.get_output_srid();
+        } else {
+          col_details.precision = ct.get_precision();
+          col_details.scale = ct.get_scale();
+        }
+        if (col_details.encoding == ColumnEncoding::DICT) {
+          // have to get the actual size of the encoding from the dictionary
+          // definition
+          const int dict_id = ct.get_comp_param();
+          auto dd = catalog.getMetadataForDict(dict_id, false);
+          if (dd) {
+            col_details.comp_param = dd->dictNBits;
+          } else {
+            throw std::runtime_error("Dictionary definition for column doesn't exist");
+          }
+        } else {
+          col_details.comp_param = ct.get_comp_param();
+          if (ct.is_date_in_days() && col_details.comp_param == 0) {
+            col_details.comp_param = 32;
+          }
+        }
+        result.push_back(col_details);
       }
-    } catch (const apache::thrift::TException& ex) {
-      throw std::runtime_error(ex.what());
     }
     return result;
   }
 
   bool setDatabase(std::string& db_name) {
-    try {
-      auto& sys_cat = Catalog_Namespace::SysCatalog::instance();
-      auto& user = db_handler_->get_session_copy(session_id_).get_currentUser();
-      sys_cat.switchDatabase(db_name, user.userName);
-    } catch (const apache::thrift::TException& ex) {
-      throw std::runtime_error(ex.what());
-    }
+    auto& sys_cat = Catalog_Namespace::SysCatalog::instance();
+    auto& user = db_handler_->get_session_copy(session_id_).get_currentUser();
+    sys_cat.switchDatabase(db_name, user.userName);
     return true;
   }
 
   bool login(std::string& db_name, std::string& user_name, const std::string& password) {
-    try {
-      db_handler_->disconnect(session_id_);
-      db_handler_->connect(session_id_, user_name, password, db_name);
-    } catch (const apache::thrift::TException& ex) {
-      throw std::runtime_error(ex.what());
-    }
+    db_handler_->disconnect(session_id_);
+    db_handler_->connect(session_id_, user_name, password, db_name);
     return true;
   }
 
@@ -373,8 +340,8 @@ class DBEngineImpl : public DBEngine {
     if (db_handler_) {
       try {
         db_handler_->disconnect(session_id_);
-      } catch (const apache::thrift::TException& ex) {
-        //scip exception in case of invalid session
+      } catch (const std::exception& e) {
+        //skip exception in case of invalid session
       }
       db_handler_->shutdown();
     }

--- a/Embedded/DBEngine.cpp
+++ b/Embedded/DBEngine.cpp
@@ -147,37 +147,37 @@ class DBEngineImpl : public DBEngine {
     prog_config_opts.system_parameters.calcite_keepalive = true;
     try {
       db_handler_ =
-        mapd::make_shared<DBHandler>(prog_config_opts.db_leaves,
-                                     prog_config_opts.string_leaves,
-                                     prog_config_opts.base_path,
-                                     prog_config_opts.allow_multifrag,
-                                     prog_config_opts.jit_debug,
-                                     prog_config_opts.intel_jit_profile,
-                                     prog_config_opts.read_only,
-                                     prog_config_opts.allow_loop_joins,
-                                     prog_config_opts.enable_rendering,
-                                     prog_config_opts.renderer_use_vulkan_driver,
-                                     prog_config_opts.enable_auto_clear_render_mem,
-                                     prog_config_opts.render_oom_retry_threshold,
-                                     prog_config_opts.render_mem_bytes,
-                                     prog_config_opts.max_concurrent_render_sessions,
-                                     prog_config_opts.reserved_gpu_mem,
-                                     prog_config_opts.render_compositor_use_last_gpu,
-                                     prog_config_opts.num_reader_threads,
-                                     prog_config_opts.authMetadata,
-                                     prog_config_opts.system_parameters,
-                                     prog_config_opts.enable_legacy_syntax,
-                                     prog_config_opts.idle_session_duration,
-                                     prog_config_opts.max_session_duration,
-                                     prog_config_opts.enable_runtime_udf,
-                                     prog_config_opts.udf_file_name,
-                                     prog_config_opts.udf_compiler_path,
-                                     prog_config_opts.udf_compiler_options,
+          mapd::make_shared<DBHandler>(prog_config_opts.db_leaves,
+                                       prog_config_opts.string_leaves,
+                                       prog_config_opts.base_path,
+                                       prog_config_opts.allow_multifrag,
+                                       prog_config_opts.jit_debug,
+                                       prog_config_opts.intel_jit_profile,
+                                       prog_config_opts.read_only,
+                                       prog_config_opts.allow_loop_joins,
+                                       prog_config_opts.enable_rendering,
+                                       prog_config_opts.renderer_use_vulkan_driver,
+                                       prog_config_opts.enable_auto_clear_render_mem,
+                                       prog_config_opts.render_oom_retry_threshold,
+                                       prog_config_opts.render_mem_bytes,
+                                       prog_config_opts.max_concurrent_render_sessions,
+                                       prog_config_opts.reserved_gpu_mem,
+                                       prog_config_opts.render_compositor_use_last_gpu,
+                                       prog_config_opts.num_reader_threads,
+                                       prog_config_opts.authMetadata,
+                                       prog_config_opts.system_parameters,
+                                       prog_config_opts.enable_legacy_syntax,
+                                       prog_config_opts.idle_session_duration,
+                                       prog_config_opts.max_session_duration,
+                                       prog_config_opts.enable_runtime_udf,
+                                       prog_config_opts.udf_file_name,
+                                       prog_config_opts.udf_compiler_path,
+                                       prog_config_opts.udf_compiler_options,
 #ifdef ENABLE_GEOS
-                                     prog_config_opts.libgeos_so_filename,
+                                       prog_config_opts.libgeos_so_filename,
 #endif
-                                     prog_config_opts.disk_cache_config,
-                                     is_new_db);
+                                       prog_config_opts.disk_cache_config,
+                                       is_new_db);
     } catch (const std::exception& e) {
       LOG(FATAL) << "Failed to initialize database handler: " << e.what();
       throw;
@@ -341,7 +341,7 @@ class DBEngineImpl : public DBEngine {
       try {
         db_handler_->disconnect(session_id_);
       } catch (const std::exception& e) {
-        //skip exception in case of invalid session
+        // skip exception in case of invalid session
       }
       db_handler_->shutdown();
     }
@@ -431,8 +431,6 @@ class DBEngineImpl : public DBEngine {
                                               "mapd_data",
                                               "mapd_export"};
 };
-
-
 
 namespace {
 std::mutex engine_create_mutex;

--- a/Embedded/Python/dbe.pyx
+++ b/Embedded/Python/dbe.pyx
@@ -232,3 +232,12 @@ cdef class PyDbEngine:
     def get_tables(self):
         self.check_closed()
         return self.c_dbe.get().getTables()
+
+    def setDatabase(self, db_name):
+        self.check_closed()
+        return self.c_dbe.get().setDatabase(db_name)
+
+    def login(self, db_name, user_name, password):
+        self.check_closed()
+        return self.c_dbe.get().login(db_name, user_name, password)
+

--- a/Embedded/test/test_exceptions.py
+++ b/Embedded/test/test_exceptions.py
@@ -65,8 +65,15 @@ def test_zero_division():
         cursor = engine.executeDML("SELECT x / (x - x) FROM test")
     assert "Division by zero" in str(excinfo.value)
 
+######################Check Authentication failure
+def test_auth_fail():
+    with pytest.raises(RuntimeError) as excinfo:
+        engine.login("db", "user", "password")
+    assert "Authentication failure" in str(excinfo.value)
+
 #######################Check double init  exception
 def test_double_init():
     with pytest.raises(RuntimeError) as excinfo:
         engine = dbe.PyDbEngine()
     assert "already initialized" in str(excinfo.value)
+


### PR DESCRIPTION
Map Omnisci exceptions to Python exceptions in DBE #2861

I decided to not process all the list of the omnisci exceptions in the DBE and use only the basic ones. The reason is that the list of exceptions is large and requires linking many files, since they are not included in one header. But they are inherited from the base std::exception, which allows us to get the error string on the Python side.
Below is a list of omnisci exceptions:

TException
TTransportException
InvalidParseRequest
CudaErrorException
OutOfMemory
TooBigForSlab
ForeignStorageException
FailedToCreateSlab
PostEvictionRefreshException(e);
GeoTypesError
InsufficientBufferSizeException
GeoImportException
ArrowImporterException
QueryExecutionError
QueryMustRunOnCpu
WatchdogException
QueryMustRunOnCpu
ColumnarConversionNotSupported
TooManyLiterals
ReductionRanOutOfSlots
OverflowOrUnderflow
CompilationRetryNewScanLimit
NativeExecutionError
ExtensionFunctionBindingError
FailedToCreateBitmap
ParseIRError
CardinalityEstimationRequired
CompilationRetryNoLazyFetch
SpeculativeTopNFailed
StreamingTopNNotSupportedInRenderQuery
QueryNotSupported
RowSortException
SpeculativeTopNFailed
CompilationRetryNoCompaction
StreamingTopNOOM
OutOfHostMemory
OutOfRenderMemory
SringConstInResultSet
TableMustBeReplicated
HashJoinFail
TooManyHashEntries
FailedToJoinOnVirtualColumn
FailedToFetchColumn
OverlapsHashTableTooBig
NeedsOneToManyHash