### PR TITLE
Apply calcite self-join fix to modin optimization pipeline

### DIFF
--- a/java/calcite/src/main/java/org/apache/calcite/prepare/MapDPlanner.java
+++ b/java/calcite/src/main/java/org/apache/calcite/prepare/MapDPlanner.java
@@ -236,7 +236,7 @@ public class MapDPlanner extends PlannerImpl {
     for (RelOptRule rule : rules) {
       programBuilder.addRuleInstance(rule);
     }
-    HepPlanner hepPlanner = MapDPlanner.getHepPlanner(programBuilder.build(), false);
+    HepPlanner hepPlanner = MapDPlanner.getHepPlanner(programBuilder.build(), true);
     hepPlanner.setRoot(root.rel);
     return root.withRel(hepPlanner.findBestExp());
   }


### PR DESCRIPTION
Fix crash in case of self-join RA queries. 

Where a binary join node has two inputs
and they are actually the same scan node referencing the same table in DB
when Calcite traverses such plan tree, they use DAG structure by default, and this means
the plan in DAG looks like:
      
   JOIN:1
SCAN:0  SCAN:0
but we are not acceptable with the same rel node id so we crash, in other words we need:         
   JOIN:2
SCAN:0  SCAN:1