### PR TITLE
Fixed syntax of llvm-glibc patch

### DIFF
--- a/scripts/llvm-9-glibc-2.31-708430.patch
+++ b/scripts/llvm-9-glibc-2.31-708430.patch
@@ -1,12 +1,12 @@
----compiler - rt / lib / sanitizer_common / sanitizer_platform_limits_posix.cc.orig 2020 -
-    03 - 11 20 : 35 : 37.099808821 + 0100 +++compiler -
-    rt / lib / sanitizer_common / sanitizer_platform_limits_posix.cc 2020 - 03 -
-    11 20 : 36 : 08.279808758 + 0100 @ @-1128,
-    7 + 1128, 7 @ @CHECK_SIZE_AND_OFFSET(ipc_perm, cgid);
-#if !defined(__aarch64__) || !SANITIZER_LINUX || __GLIBC_PREREQ(2, 21)
-/* On aarch64 glibc 2.20 and earlier provided incorrect mode field.  */
-- CHECK_SIZE_AND_OFFSET(ipc_perm, mode);
-+  // CHECK_SIZE_AND_OFFSET(ipc_perm, mode);
-#endif
-
-    CHECK_TYPE_SIZE(shmid_ds);
+diff -ur compiler-rt.orig/lib/sanitizer_common/sanitizer_platform_limits_posix.cc compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cc
+--- compiler-rt.orig/lib/sanitizer_common/sanitizer_platform_limits_posix.cc	2021-05-24 18:28:25.165173185 +0100
++++ compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cc	2021-05-24 18:30:06.834758694 +0100
+@@ -1128,7 +1128,7 @@
+ CHECK_SIZE_AND_OFFSET(ipc_perm, cgid);
+ #if !defined(__aarch64__) || !SANITIZER_LINUX || __GLIBC_PREREQ (2, 21)
+ /* On aarch64 glibc 2.20 and earlier provided incorrect mode field.  */
+-CHECK_SIZE_AND_OFFSET(ipc_perm, mode);
++// CHECK_SIZE_AND_OFFSET(ipc_perm, mode);
+ #endif
+ 
+ CHECK_TYPE_SIZE(shmid_ds);


### PR DESCRIPTION
File llvm-9-glibc-2.31-708430.patch has some weird syntax that is not accepted by patch command in Ubuntu 20.04.2. This PR fixes it to a generally accepted syntax.