### PR TITLE
Remove unnecessary memory accesses from CPU codegen

### DIFF
--- a/QueryEngine/GroupByAndAggregate.cpp
+++ b/QueryEngine/GroupByAndAggregate.cpp
@@ -1022,12 +1022,10 @@ llvm::Value* GroupByAndAggregate::codegenOutputSlot(
          null_key_lv,
          order_entry_lv});
   } else {
-    const auto output_buffer_entry_count_lv =
-        LL_BUILDER.CreateLoad(get_arg_by_name(ROW_FUNC, "max_matched"));
     const auto group_expr_lv =
         LL_BUILDER.CreateLoad(get_arg_by_name(ROW_FUNC, "old_total_matched"));
     std::vector<llvm::Value*> args{groups_buffer,
-                                   output_buffer_entry_count_lv,
+                                   get_arg_by_name(ROW_FUNC, "max_matched"),
                                    group_expr_lv,
                                    code_generator.posArg(nullptr)};
     if (query_mem_desc.didOutputColumnar()) {

--- a/QueryEngine/NativeCodegen.cpp
+++ b/QueryEngine/NativeCodegen.cpp
@@ -1584,7 +1584,7 @@ llvm::Function* create_row_function(const size_t in_col_count,
     // old total match count returned to the caller
     row_process_arg_types.push_back(llvm::Type::getInt32PtrTy(context));
     // max matched (total number of slots in the output buffer)
-    row_process_arg_types.push_back(llvm::Type::getInt32PtrTy(context));
+    row_process_arg_types.push_back(llvm::Type::getInt32Ty(context));
   }
 
   // aggregate init values

--- a/QueryEngine/RuntimeFunctions.cpp
+++ b/QueryEngine/RuntimeFunctions.cpp
@@ -1524,18 +1524,19 @@ extern "C" NEVER_INLINE void query_stub_hoisted_literals(const int8_t** col_buff
 #endif
 }
 
-extern "C" void multifrag_query_hoisted_literals(const int8_t*** col_buffers,
-                                                 const uint64_t* num_fragments,
-                                                 const int8_t* literals,
-                                                 const int64_t* num_rows,
-                                                 const uint64_t* frag_row_offsets,
-                                                 const int32_t* max_matched,
-                                                 int32_t* total_matched,
-                                                 const int64_t* init_agg_value,
-                                                 int64_t** out,
-                                                 int32_t* error_code,
-                                                 const uint32_t* num_tables_ptr,
-                                                 const int64_t* join_hash_tables) {
+extern "C" void multifrag_query_hoisted_literals(
+    const int8_t*** col_buffers,
+    const uint64_t* __restrict__ num_fragments,
+    const int8_t* literals,
+    const int64_t* num_rows,
+    const uint64_t* frag_row_offsets,
+    const int32_t* max_matched,
+    int32_t* total_matched,
+    const int64_t* init_agg_value,
+    int64_t** out,
+    int32_t* error_code,
+    const uint32_t* __restrict__ num_tables_ptr,
+    const int64_t* join_hash_tables) {
   for (uint32_t i = 0; i < *num_fragments; ++i) {
     query_stub_hoisted_literals(col_buffers ? col_buffers[i] : nullptr,
                                 literals,
@@ -1568,7 +1569,7 @@ extern "C" NEVER_INLINE void query_stub(const int8_t** col_buffers,
 }
 
 extern "C" void multifrag_query(const int8_t*** col_buffers,
-                                const uint64_t* num_fragments,
+                                const uint64_t* __restrict__ num_fragments,
                                 const int64_t* num_rows,
                                 const uint64_t* frag_row_offsets,
                                 const int32_t* max_matched,
@@ -1576,7 +1577,7 @@ extern "C" void multifrag_query(const int8_t*** col_buffers,
                                 const int64_t* init_agg_value,
                                 int64_t** out,
                                 int32_t* error_code,
-                                const uint32_t* num_tables_ptr,
+                                const uint32_t* __restrict__ num_tables_ptr,
                                 const int64_t* join_hash_tables) {
   for (uint32_t i = 0; i < *num_fragments; ++i) {
     query_stub(col_buffers ? col_buffers[i] : nullptr,


### PR DESCRIPTION
It speeds up lauchCpuCode stage by around 30% for the following query for row-wise output:
```sql
SELECT x*2 FROM table;
```