### PR TITLE
Update streaming tests with table modification

### DIFF
--- a/DataMgr/PersistentStorageMgr/PersistentStorageMgr.cpp
+++ b/DataMgr/PersistentStorageMgr/PersistentStorageMgr.cpp
@@ -175,7 +175,13 @@ foreign_storage::ForeignStorageCache* PersistentStorageMgr::getDiskCache() const
 
 void PersistentStorageMgr::registerDataProvider(
     int schema_id,
-    std::unique_ptr<AbstractBufferMgr> provider) {
+    std::shared_ptr<AbstractBufferMgr> provider) {
   CHECK_EQ(mgr_by_schema_id_.count(schema_id), 0);
-  mgr_by_schema_id_[schema_id] = std::move(provider);
+  mgr_by_schema_id_[schema_id] = provider;
+}
+
+std::shared_ptr<AbstractBufferMgr> PersistentStorageMgr::getDataProvider(
+    int schema_id) const {
+  CHECK_EQ(mgr_by_schema_id_.count(schema_id), 1);
+  return mgr_by_schema_id_.at(schema_id);
 }

--- a/DataMgr/PersistentStorageMgr/PersistentStorageMgr.h
+++ b/DataMgr/PersistentStorageMgr/PersistentStorageMgr.h
@@ -74,7 +74,9 @@ class PersistentStorageMgr : public AbstractBufferMgr {
     return fsi_;
   }
 
-  void registerDataProvider(int schema_id, std::unique_ptr<AbstractBufferMgr>);
+  void registerDataProvider(int schema_id, std::shared_ptr<AbstractBufferMgr>);
+
+  std::shared_ptr<AbstractBufferMgr> getDataProvider(int schema_id) const;
 
  protected:
   bool isForeignStorage(const ChunkKey& chunk_key) const;
@@ -85,5 +87,5 @@ class PersistentStorageMgr : public AbstractBufferMgr {
   std::unique_ptr<foreign_storage::ForeignStorageCache> disk_cache_;
   File_Namespace::DiskCacheConfig disk_cache_config_;
   std::shared_ptr<ForeignStorageInterface> fsi_;
-  std::unordered_map<int, std::unique_ptr<AbstractBufferMgr>> mgr_by_schema_id_;
+  std::unordered_map<int, std::shared_ptr<AbstractBufferMgr>> mgr_by_schema_id_;
 };

--- a/Tests/NoCatalogSqlTest.cpp
+++ b/Tests/NoCatalogSqlTest.cpp
@@ -289,6 +289,37 @@ TEST_F(NoCatalogSqlTest, StreamingAggregate) {
   TestHelpers::compare_arrow_table(at, std::vector<int64_t>{41});
 }
 
+TEST_F(NoCatalogSqlTest, StreamingFilter) {
+  GTEST_SKIP();
+  auto ra_executor = getExecutor("SELECT val FROM test_streaming WHERE val > 20;");
+  ra_executor.prepareStreamingExecution(CompilationOptions(), ExecutionOptions());
+
+  std::vector<std::string> col_names;
+  col_names.push_back("val");
+
+  TestDataProvider& data_provider = getDataProvider();
+
+  data_provider.addTableColumn<int32_t>(TEST_STREAMING_TABLE_ID, 1, {10, 20, 30});
+  data_provider.addTableColumn<int32_t>(TEST_STREAMING_TABLE_ID, 1, {2, 1, 2});
+  data_provider.addTableColumn<int32_t>(TEST_STREAMING_TABLE_ID, 2, {3, 30, 3});
+  data_provider.addTableColumn<int32_t>(TEST_STREAMING_TABLE_ID, 2, {30, 1, 40});
+
+  auto rs = ra_executor.runOnBatch({TEST_STREAMING_TABLE_ID, {0, 1}});
+
+  auto converter = std::make_unique<ArrowResultSetConverter>(rs, col_names, -1);
+  auto at = converter->convertToArrowTable();
+  TestHelpers::compare_arrow_table(at, std::vector<int64_t>{30, 30, 40});
+
+  data_provider.addTableColumn<int32_t>(TEST_STREAMING_TABLE_ID, 1, {40, 50, 60});
+  data_provider.addTableColumn<int32_t>(TEST_STREAMING_TABLE_ID, 2, {70, 8, 90});
+
+  rs = ra_executor.runOnBatch({TEST_STREAMING_TABLE_ID, {2}});
+
+  converter = std::make_unique<ArrowResultSetConverter>(rs, col_names, -1);
+  at = converter->convertToArrowTable();
+  TestHelpers::compare_arrow_table(at, std::vector<int64_t>{70, 90});
+}
+
 int main(int argc, char** argv) {
   TestHelpers::init_logger_stderr_only(argc, argv);
   testing::InitGoogleTest(&argc, argv);

--- a/Tests/TestDataProvider.h
+++ b/Tests/TestDataProvider.h
@@ -226,6 +226,12 @@ class TestDataProvider : public AbstractBufferMgr {
     return 0;
   }
 
+  template <typename T>
+  void addTableColumn(int table_id, size_t col_id, const std::vector<T>& vals) {
+    CHECK_EQ(tables_.count(table_id), 1);
+    tables_.at(table_id).addColFragment<T>(col_id, vals);
+  }
+
  protected:
   int db_id_;
   SchemaProviderPtr schema_provider_;


### PR DESCRIPTION
Now data is added to the table between two runs.