### PR TITLE
Novichkovg/jit engine

### DIFF
--- a/QueryEngine/CMakeLists.txt
+++ b/QueryEngine/CMakeLists.txt
@@ -48,6 +48,8 @@ set(query_engine_source_files
     ExternalExecutor.cpp
     ExtractFromTime.cpp
     FromTableReordering.cpp
+#    GeoIR.cpp
+    Globals.cpp
     GpuInterrupt.cpp
     GpuMemUtils.cpp
     GpuSharedMemoryUtils.cpp

--- a/QueryEngine/CompilationOptions.h
+++ b/QueryEngine/CompilationOptions.h
@@ -38,6 +38,7 @@ struct CompilationOptions {
                                         // scans. Primarily disabled for delete queries.
   ExecutorExplainType explain_type{ExecutorExplainType::Default};
   bool register_intel_jit_listener{false};
+  bool use_groupby_buffer_desc{false};
 
   static CompilationOptions makeCpuOnly(const CompilationOptions& in) {
     return CompilationOptions{ExecutorDeviceType::CPU,
@@ -47,7 +48,8 @@ struct CompilationOptions {
                               in.allow_lazy_fetch,
                               in.filter_on_deleted_column,
                               in.explain_type,
-                              in.register_intel_jit_listener};
+                              in.register_intel_jit_listener,
+                              in.use_groupby_buffer_desc};
   }
 
   static CompilationOptions defaults(
@@ -59,6 +61,7 @@ struct CompilationOptions {
                               true,
                               true,
                               ExecutorExplainType::Default,
+                              false,
                               false};
   }
 };

--- a/QueryEngine/Globals.cpp
+++ b/QueryEngine/Globals.cpp
@@ -1,0 +1,2 @@
+// Globals
+bool    g_use_groupby_buffer_desc = false;      //  if true, size agnostic regime is used

--- a/QueryEngine/Globals.h
+++ b/QueryEngine/Globals.h
@@ -1,0 +1,1 @@
+extern bool g_use_groupby_buffer_desc;

--- a/QueryEngine/HashTableDesc.h
+++ b/QueryEngine/HashTableDesc.h
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef HASH_TABLE_DESC_H
+#define HASH_TABLE_DESC_H
+
+#include <cstdint>
+
+struct HashTableDesc {
+  int8_t* ptr{nullptr};
+  size_t size{0};
+
+  HashTableDesc(int8_t*, size_t);
+  HashTableDesc() = default;
+};
+
+inline __attribute__((always_inline))
+HashTableDesc::HashTableDesc(int8_t* ptr_, size_t size_)
+    : ptr(ptr_), size(size_) {}
+
+#endif  // HASH_TABLE_DESC_H

--- a/QueryEngine/QueryMemoryInitializer.h
+++ b/QueryEngine/QueryMemoryInitializer.h
@@ -50,7 +50,8 @@ class QueryMemoryInitializer {
                          std::shared_ptr<RowSetMemoryOwner> row_set_mem_owner,
                          DeviceAllocator* gpu_allocator,
                          const size_t thread_idx,
-                         const Executor* executor);
+                         const Executor* executor,
+                         bool use_hash_table_desc = false);
 
   // Table functions execution constructor
   QueryMemoryInitializer(const TableFunctionExecutionUnit& exe_unit,
@@ -62,7 +63,10 @@ class QueryMemoryInitializer {
                          const std::vector<std::vector<uint64_t>>& frag_offsets,
                          std::shared_ptr<RowSetMemoryOwner> row_set_mem_owner,
                          DeviceAllocator* device_allocator,
-                         const Executor* executor);
+                         const Executor* executor,
+                         bool use_hash_table_desc = false);
+
+  ~QueryMemoryInitializer();
 
   const auto getCountDistinctBitmapPtr() const { return count_distinct_bitmap_mem_; }
 
@@ -96,6 +100,14 @@ class QueryMemoryInitializer {
     CHECK_LT(index, init_agg_vals_.size());
     return init_agg_vals_[index];
   }
+
+  // const std::vector <int64_t*> getGroupByHashTableDescPtr() {
+  //   std::vector <int64_t*> rv;
+  //   for (auto *desc: group_by_hash_tabler_descs_) {
+  //     rv.push_back(reinterpret_cast<int64_t*>(desc));
+  //   }
+  //   return rv;
+  // }
 
   const auto getGroupByBuffersPtr() {
     return reinterpret_cast<int64_t**>(group_by_buffers_.data());
@@ -231,6 +243,8 @@ class QueryMemoryInitializer {
 
   size_t num_buffers_;
   std::vector<int64_t*> group_by_buffers_;
+  // std::vector<HashTableDesc*> group_by_hash_table_descs_;
+
   std::shared_ptr<VarlenOutputInfo> varlen_output_info_;
   CUdeviceptr varlen_output_buffer_;
   int8_t* varlen_output_buffer_host_ptr_;
@@ -243,6 +257,7 @@ class QueryMemoryInitializer {
   DeviceAllocator* device_allocator_{nullptr};
   std::vector<Data_Namespace::AbstractBuffer*> temporary_buffers_;
 
+  bool use_hash_table_desc_;
   const size_t thread_idx_;
 
   friend class Executor;  // Accesses result_sets_

--- a/QueryEngine/ResultSetStorage.cpp
+++ b/QueryEngine/ResultSetStorage.cpp
@@ -58,6 +58,7 @@ ResultSetStorage::ResultSetStorage(const std::vector<TargetInfo>& targets,
                                    const bool buff_is_provided)
     : targets_(targets)
     , query_mem_desc_(query_mem_desc)
+    , hash_table_desc_{buff, query_mem_desc.getEntryCount()}
     , buff_(buff)
     , buff_is_provided_(buff_is_provided)
     , target_init_vals_(result_set::initialize_target_values_for_storage(targets)) {}

--- a/QueryEngine/ResultSetStorage.h
+++ b/QueryEngine/ResultSetStorage.h
@@ -27,6 +27,7 @@
 
 #include "CardinalityEstimator.h"
 #include "DataMgr/Chunk/Chunk.h"
+#include "HashTableDesc.h"
 #include "ResultSetBufferAccessors.h"
 #include "TargetValue.h"
 
@@ -237,6 +238,7 @@ class ResultSetStorage {
 
   const std::vector<TargetInfo> targets_;
   QueryMemoryDescriptor query_mem_desc_;
+  HashTableDesc hash_table_desc_;
   int8_t* buff_;
   const bool buff_is_provided_;
   std::vector<int64_t> target_init_vals_;

--- a/Tests/ExecuteTest.cpp
+++ b/Tests/ExecuteTest.cpp
@@ -23,6 +23,7 @@
 #include "../QueryEngine/Descriptors/RelAlgExecutionDescriptor.h"
 #include "../QueryEngine/Execute.h"
 #include "../QueryEngine/ExpressionRange.h"
+#include "../QueryEngine/Globals.h"
 #include "../QueryEngine/ResultSetReductionJIT.h"
 #include "../QueryRunner/QueryRunner.h"
 #include "../Shared/DateConverters.h"
@@ -19321,6 +19322,11 @@ int main(int argc, char** argv) {
                          ->default_value(g_enable_bump_allocator)
                          ->implicit_value(true),
                      "Enable the bump allocator for projection queries on GPU.");
+  desc.add_options()("use_groupby_buffer_desc",
+                     po::value<bool>(&g_use_groupby_buffer_desc)
+                         ->default_value(g_use_groupby_buffer_desc)
+                         ->implicit_value(true),
+                     "Use GroupBy Buffer Descriptor for hash tables.");
   desc.add_options()("keep-data", "Don't drop tables at the end of the tests");
   desc.add_options()("use-existing-data",
                      "Don't create and drop tables and only run select tests (it "

--- a/ThriftHandler/CommandLineOptions.h
+++ b/ThriftHandler/CommandLineOptions.h
@@ -215,3 +215,4 @@ extern bool g_enable_data_recycler;
 extern bool g_use_hashtable_cache;
 extern size_t g_hashtable_cache_total_bytes;
 extern size_t g_max_cacheable_hashtable_size_bytes;
+extern bool g_use_groupby_buffer_desc;

--- a/ThriftHandler/DBHandler.cpp
+++ b/ThriftHandler/DBHandler.cpp
@@ -35,6 +35,7 @@
 #include "gen-cpp/CalciteServer.h"
 
 #include "QueryEngine/ErrorHandling.h"
+#include "QueryEngine/Globals.h"
 #include "QueryEngine/RelAlgExecutor.h"
 
 #include "Catalog/Catalog.h"
@@ -4417,6 +4418,7 @@ std::vector<PushedDownFilterInfo> DBHandler::execute_rel_alg(
                              &cat,
                              query_ra,
                              query_state_proxy.getQueryState().shared_from_this());
+
   CompilationOptions co = {executor_device_type,
                            /*hoist_literals=*/true,
                            ExecutorOptLevel::Default,
@@ -4425,7 +4427,9 @@ std::vector<PushedDownFilterInfo> DBHandler::execute_rel_alg(
                            /*filter_on_deleted_column=*/true,
                            explain_info.explain_optimized ? ExecutorExplainType::Optimized
                                                           : ExecutorExplainType::Default,
-                           intel_jit_profile_};
+                           intel_jit_profile_,
+                           g_use_groupby_buffer_desc};
+
   auto validate_or_explain_query =
       explain_info.justExplain() || explain_info.justCalciteExplain() || just_validate;
   ExecutionOptions eo = {g_enable_columnar_output,
@@ -4489,6 +4493,7 @@ void DBHandler::execute_rel_alg_df(TDataFrame& _return,
                              &cat,
                              query_ra,
                              query_state_proxy.getQueryState().shared_from_this());
+
   CompilationOptions co = {executor_device_type,
                            /*hoist_literals=*/true,
                            ExecutorOptLevel::Default,
@@ -4496,7 +4501,9 @@ void DBHandler::execute_rel_alg_df(TDataFrame& _return,
                            /*allow_lazy_fetch=*/true,
                            /*filter_on_deleted_column=*/true,
                            ExecutorExplainType::Default,
-                           intel_jit_profile_};
+                           intel_jit_profile_,
+                           g_use_groupby_buffer_desc};
+
   ExecutionOptions eo = {
       g_enable_columnar_output,
       allow_multifrag_,


### PR DESCRIPTION
To enable size agnostic regime, set `g_use_groupby_buffer_desc = true` in `QueryEngine/Globals.cpp`. By default, it is set to `false`.