### PR TITLE
Refactoring: split execution kernels storage per device type

### DIFF
--- a/QueryEngine/CMakeLists.txt
+++ b/QueryEngine/CMakeLists.txt
@@ -26,6 +26,7 @@ set(query_engine_source_files
     ColumnFetcher.cpp
     ColumnIR.cpp
     CompareIR.cpp
+    CompilationOptions.cpp
     ConstantIR.cpp
     DateTimeIR.cpp
     DateTimePlusRewrite.cpp

--- a/QueryEngine/CompilationOptions.cpp
+++ b/QueryEngine/CompilationOptions.cpp
@@ -1,0 +1,7 @@
+#include "QueryEngine/CompilationOptions.h"
+#include <ostream>
+
+std::ostream& operator<<(std::ostream& os, const ExecutorDeviceType& dt) {
+  os << (dt == ExecutorDeviceType::CPU ? "CPU" : "GPU");
+  return os;
+}

--- a/QueryEngine/CompilationOptions.cpp
+++ b/QueryEngine/CompilationOptions.cpp
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 OmniSci, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include "QueryEngine/CompilationOptions.h"
 #include <ostream>
 

--- a/QueryEngine/CompilationOptions.h
+++ b/QueryEngine/CompilationOptions.h
@@ -28,6 +28,8 @@ enum class ExecutorExplainType { Default, Optimized };
 
 enum class ExecutorDispatchMode { KernelPerFragment, MultifragmentKernel };
 
+std::ostream& operator<<(std::ostream& os, const ExecutorDeviceType& dt);
+
 struct CompilationOptions {
   ExecutorDeviceType device_type;
   bool hoist_literals;


### PR DESCRIPTION
I'd like to store execution kernels for different device type separately as it would help schedule gpu and cpu kernels with the same device_id differently (single kernel per fragment for cpu vs multifrag for gpu).