### PR TITLE
Fix for recent CVE's, dep's list reduction

### DIFF
--- a/Calcite/java/calcite/pom.xml
+++ b/Calcite/java/calcite/pom.xml
@@ -15,12 +15,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
   </properties>
-  <dependencies>
-    <dependency>
-      <groupId>commons-cli</groupId>
-      <artifactId>commons-cli</artifactId>
-      <version>1.3.1</version>
-    </dependency>
+  <dependencies>    
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
@@ -51,6 +46,18 @@
       <artifactId>avatica-core</artifactId>
       <version>1.17.0</version>
     </dependency>
+    <!-- Added to override avatica-core pin to vulnerable jackson-databind 2.10 -->
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.13.3</version>      
+    </dependency>
+    <!-- Added to override avatica-core pin to vulnerable jackson-databind 2.10 -->
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <version>2.13.3</version>
+    </dependency>
     <dependency>
       <groupId>org.apache.calcite</groupId>
       <artifactId>calcite-core</artifactId>
@@ -67,11 +74,6 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.xerial</groupId>
-      <artifactId>sqlite-jdbc</artifactId>
-      <version>3.30.1</version>
-    </dependency>
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.13.1</version>
@@ -81,7 +83,7 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.8.6</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
   <build>


### PR DESCRIPTION
* Updated gson, jackson-databind version to mitigate critical/high CVE's
* Removed unused dependencies - sqlite-jdbc, commons-cli